### PR TITLE
Pull Request: Implemented funcionality to show both faces in cards two-faced

### DIFF
--- a/app/src/main/java/pol/rubiano/magicapp/app/common/extensions/CardBindingHandler.kt
+++ b/app/src/main/java/pol/rubiano/magicapp/app/common/extensions/CardBindingHandler.kt
@@ -5,17 +5,64 @@ import pol.rubiano.magicapp.app.domain.entities.Card
 import pol.rubiano.magicapp.databinding.RandomCardFragmentBinding
 
 class CardBindingHandler {
+    private var currentCard: Card? = null
+    private var isTwoFaced: Boolean = false
+    private var isFront: Boolean = true
 
     fun bind(card: Card, binding: RandomCardFragmentBinding) {
+        currentCard = card
+        isTwoFaced = (card.frontFace != null && card.backFace != null)
+        isFront = true
+
         binding.apply {
-            card.borderCrop?.let { randomCardImage.loadUrl(it) }
-            randomCardName.text = card.name
-            randomCardTipeLine.text = card.typeLine
             randomCardRarity.text = card.rarity
             randomCardSetName.text = card.setName
 
-            card.oracleText?.let { cost ->
-                randomCardOracleText.text = mapManaSymbols(randomCardOracleText.context, cost)
+            if (isTwoFaced) {
+                updateVariableFields(card.frontFace, card, binding)
+            } else {
+                updateVariableFields(null, card, binding)
+            }
+        }
+    }
+
+    private fun updateVariableFields(
+        face: Card.Face?,
+        card: Card,
+        binding: RandomCardFragmentBinding
+    ) {
+        binding.apply {
+            if (face != null) {
+                randomCardName.text = face.faceName ?: card.name
+                randomCardTipeLine.text = face.faceTypeLine ?: card.typeLine
+                face.faceOracleText?.let {
+                    randomCardOracleText.text = mapManaSymbols(randomCardOracleText.context, it)
+                } ?: card.oracleText?.let {
+                    randomCardOracleText.text = mapManaSymbols(randomCardOracleText.context, it)
+                }
+                val imageUrl = face.faceBorderCrop ?: card.borderCrop
+                imageUrl?.let { randomCardImage.loadUrl(it) }
+            } else {
+                randomCardName.text = card.name
+                randomCardTipeLine.text = card.typeLine
+                card.oracleText?.let {
+                    randomCardOracleText.text = mapManaSymbols(randomCardOracleText.context, it)
+                }
+                card.borderCrop?.let { randomCardImage.loadUrl(it) }
+            }
+        }
+    }
+
+    fun flipCard(binding: RandomCardFragmentBinding) {
+        val card = currentCard ?: return
+        if (!isTwoFaced) return
+
+        isFront = !isFront
+        binding.apply {
+            if (isFront) {
+                updateVariableFields(card.frontFace, card, binding)
+            } else {
+                updateVariableFields(card.backFace, card, binding)
             }
         }
     }

--- a/app/src/main/java/pol/rubiano/magicapp/app/data/CardDataRepository.kt
+++ b/app/src/main/java/pol/rubiano/magicapp/app/data/CardDataRepository.kt
@@ -28,9 +28,7 @@ class CardDataRepository(
 
         val remoteCard = remote.getRandomCard()
         val card = remoteCard.getOrNull()
-        if(card != null){
-
-            Log.d("@POL", "CardDataRepository - getRandomCard: $card")
+        if (card != null) {
             // TODO - comprobar si está en local
             local.saveCardToLocal(card)
 
@@ -40,12 +38,12 @@ class CardDataRepository(
             }
 
             card.frontFace?.faceBorderCrop?.let { frontImageUrl ->
-                val fileName = "${card.id}.png"
+                val fileName = "${card.id}_front.png"
                 downloadAndSaveImage(context, frontImageUrl, fileName)
             }
 
             card.backFace?.faceBorderCrop?.let { backImageUrl ->
-                val fileName = "${card.id}.png"
+                val fileName = "${card.id}_back.png"
                 downloadAndSaveImage(context, backImageUrl, fileName)
             }
 
@@ -54,7 +52,11 @@ class CardDataRepository(
         return Result.failure(ErrorApp.ServerErrorApp)
     }
 
-    private suspend fun downloadAndSaveImage(context: Context, imageUrl: String, fileName: String): Boolean {
+    private suspend fun downloadAndSaveImage(
+        context: Context,
+        imageUrl: String,
+        fileName: String
+    ): Boolean {
         return withContext(Dispatchers.IO) {
             try {
                 val url = URL(imageUrl)

--- a/app/src/main/java/pol/rubiano/magicapp/features/presentation/ui/RandomCardFragment.kt
+++ b/app/src/main/java/pol/rubiano/magicapp/features/presentation/ui/RandomCardFragment.kt
@@ -44,6 +44,20 @@ class RandomCardFragment : Fragment() {
         if (savedInstanceState == null && viewModel.uiState.value?.card == null) {
             viewModel.fetchRandomCard()
         }
+        binding.randomCardImage.post {
+            val density = resources.displayMetrics.density
+            binding.randomCardImage.pivotX = binding.randomCardImage.width / 2f
+            binding.randomCardImage.pivotY = binding.randomCardImage.height / 2f
+            binding.randomCardImage.cameraDistance = 8000 * density
+        }
+        binding.flipButton.setOnClickListener {
+            binding.randomCardImage.animate().rotationY(90f).setDuration(300)
+                .withEndAction {
+                    cardBinder.flipCard(binding)
+                    binding.randomCardImage.rotationY = -90f
+                    binding.randomCardImage.animate().rotationY(0f).setDuration(300).start()
+                }.start()
+        }
     }
 
     private fun setupLegalitiesRecyclerView() {
@@ -61,9 +75,15 @@ class RandomCardFragment : Fragment() {
             bindError(uiState.errorApp)
             uiState.card?.let { card ->
                 cardBinder.bind(card, binding)
+
                 card.legalities?.let { legalities ->
                     val legalityItems = legalities.toLegalityItemList()
                     (binding.legalitiesList.adapter as LegalitiesAdapter).submitList(legalityItems)
+                }
+                if (card.frontFace != null && card.backFace != null) {
+                    binding.flipButton.visibility = View.VISIBLE
+                } else {
+                    binding.flipButton.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/res/drawable/flip.xml
+++ b/app/src/main/res/drawable/flip.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m360,800 l-56,-56 70,-72q-128,-17 -211,-70T80,480q0,-83 115.5,-141.5T480,280q169,0 284.5,58.5T880,480q0,62 -66.5,111T640,664v-82q77,-20 118.5,-49.5T800,480q0,-32 -85.5,-76T480,360q-149,0 -234.5,44T160,480q0,24 51,57.5T356,588l-52,-52 56,-56 160,160 -160,160Z"
+      android:fillColor="#242525"/>
+</vector>

--- a/app/src/main/res/layout/random_card_fragment.xml
+++ b/app/src/main/res/layout/random_card_fragment.xml
@@ -24,6 +24,18 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:src="@drawable/card_back" />
 
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/flip_button"
+                style="?attr/floatingActionButtonSurfaceStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/fab_flip"
+                android:layout_marginEnd="@dimen/dimen_l"
+                android:src="@drawable/flip"
+                app:layout_constraintTop_toTopOf="@id/random_card_image"
+                app:layout_constraintEnd_toEndOf="@id/random_card_image"
+                app:layout_constraintBottom_toBottomOf="@id/random_card_image"/>
+
             <!-- Name -->
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/name_title"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -19,4 +19,5 @@
     <string name="cd_save_card">Guarda la carta de la imagen dentro del almacenamiento de la aplicación</string>
     <string name="refresh">Recargar</string>
     <string name="cd_refresh">Recarga el contenido con una nueva carta aleatoria</string>
+    <string name="fab_flip">Girar carta</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,7 +4,8 @@
     <color name="md_theme_primaryContainer">#C4A76D</color>
     <color name="md_theme_onPrimaryContainer">#503C0C</color>
     <color name="md_theme_secondary">#242525</color>
-    <color name="md_theme_secondary_50">#80242525</color>
+    <color name="md_theme_secondary_50">#B2242525</color>
+    <color name="md_theme_secondary_70">#B2242525</color>
     <color name="md_theme_onSecondary">#FFFFFF</color>
     <color name="md_theme_secondaryContainer">#3A3A3A</color>
     <color name="md_theme_onSecondaryContainer">#A5A4A3</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="cd_save_card">Save the card\'s image into app storage</string>
     <string name="refresh">Refresh</string>
     <string name="cd_refresh">Refresh the content with a new random card</string>
+    <string name="fab_flip">Flip card</string>
 
     <!-- navigation bar -->
     <string name="magic" translatable="false">Magic</string>


### PR DESCRIPTION
## 🤔 Problem Description
Entre las cartas de Magic se encuentran casos de cartas que pueden tener impresión por ambas caras. Con esa mejora, ha implementado un botón que aparece sobre la carta en caso de que tenga dos impresiones. Al pulsar el botón, se muestra el back-face y la información del fragmento se actualiza con el contenido de esa backface. Pulsando de nuevo el botón, se intercambia con la cara principal y actualiza la información en consecuencia

## 📌 Changes Made
List the main changes introduced in this PR:
- [ ] Se ha actualizado el CardBindingHandler para que reconozca las cartas two-faced y muestre/oculte un botón para lanzar la funcionalidad que gira la imagen y muestra la información correspondiente a cada cara.
- [ ] Se ha actualizado el rpositorio para que guarde las imagenes correspondientes con un sufijo "_front" y "_back" con el fin de reconocer las caras en las imágenes guardadas.

## 🔗 References & Resources
Closes #19 .

## ✅ Checklist
The branch follows the correct format:
- [x] `enhancement/issue_number/short_description`.
- [x] I have added a clear and descriptive title.
- [x] I have assigned myself as the author.
- [x] This request is linked to the relevant issue.
- [x] I have ensured compatibility with the existing code.
- [ ] Documentation updated.